### PR TITLE
Some performance improvements / logic fixes

### DIFF
--- a/HydrateOrDiedrate/src/Aquifer/Patches/BlockAccessorWorldGenPatch.cs
+++ b/HydrateOrDiedrate/src/Aquifer/Patches/BlockAccessorWorldGenPatch.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using HarmonyLib;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -7,80 +8,28 @@ using Vintagestory.Server;
 
 namespace HydrateOrDiedrate;
 
+//TODO this method can potentially be called multiple times for the same blockPos, so might be better to just remove this altogether and rely on `CalculateAquiferData`
 [HarmonyPatch(typeof(BlockAccessorWorldGen), nameof(BlockAccessorWorldGen.SetFluidBlock))]
-public class BlockAccessorWorldGen_SetFluidBlock_Patch
+public static class BlockAccessorWorldGenPatch
 {
-    static void Postfix(int blockId, BlockPos pos, BlockAccessorWorldGen __instance)
+    public static void Postfix(int blockId, BlockPos pos, BlockAccessorWorldGen __instance)
     {
-        Block block = __instance.GetBlock(blockId);
+        var block = __instance.GetBlock(blockId);
         if (block == null) return;
 
-        string blockCode = block.Code.ToString();
-        if (!(blockCode.StartsWith("game:water") || blockCode.StartsWith("game:saltwater") || blockCode.StartsWith("game:boilingwater")))
-            return;
+        if(block.Code.Domain != "game") return;
+        var path = block.Code.Path;
 
-        IWorldChunk chunk = __instance.GetChunkAtBlockPos(pos) as IWorldChunk;
-        if (chunk == null) return;
-        EnsureModdataInitialized(chunk, "game:water");
-        EnsureModdataInitialized(chunk, "game:saltwater");
-        EnsureModdataInitialized(chunk, "game:boilingwater");
-        if (blockCode.StartsWith("game:saltwater"))
-        {
-            int saltWaterCount = chunk.GetModdata<int>("game:saltwater", 0);
-            chunk.SetModdata("game:saltwater", saltWaterCount + 1);
-        }
-        else if (blockCode.StartsWith("game:boilingwater"))
-        {
-            int boilingWaterCount = chunk.GetModdata<int>("game:boilingwater", 0);
-            chunk.SetModdata("game:boilingwater", boilingWaterCount + 1);
-        }
-        else if (blockCode.StartsWith("game:water"))
-        {
-            int normalWaterCount = chunk.GetModdata<int>("game:water", 0);
-            chunk.SetModdata("game:water", normalWaterCount + 1);
-        }
+        string key = null;
+        if (path.StartsWith("water")) key = "game:water";
+        else if (path.StartsWith("saltwater")) key = "game:saltwater";
+        else if (path.StartsWith("boilingwater")) key = "game:boilingwater";
 
-        chunk.MarkModified();
-    }
+        if(key == null) return;
 
-    private static void EnsureModdataInitialized(IWorldChunk chunk, string key)
-    {
-        if (chunk.GetModdata<int?>(key) == null)
-        {
-            chunk.SetModdata(key, 0);
-        }
-    }
+        var chunk = __instance.GetChunkAtBlockPos(pos);
+        if(chunk == null) return;
 
-    [HarmonyPatch]
-    public class ChunkServerThread_GetGeneratingChunk_Patch
-    {
-        static MethodBase TargetMethod()
-        {
-            return AccessTools.Method(
-                typeof(ChunkServerThread),
-                "GetGeneratingChunk",
-                new[] { typeof(int), typeof(int), typeof(int) }
-            );
-        }
-
-        static void Postfix(object __result)
-        {
-            if (__result is ServerChunk chunk)
-            {
-                EnsureModdataInitialized(chunk, "game:water");
-                EnsureModdataInitialized(chunk, "game:saltwater");
-                EnsureModdataInitialized(chunk, "game:boilingwater");
-
-                chunk.MarkModified();
-            }
-        }
-
-        private static void EnsureModdataInitialized(IWorldChunk chunk, string key)
-        {
-            if (chunk.GetModdata<int?>(key) == null)
-            {
-                chunk.SetModdata(key, 0);
-            }
-        }
+        chunk.SetModdata(key, chunk.GetModdata(key, 0) + 1);
     }
 }


### PR DESCRIPTION
# CalculateAquiferData:
 - Now just iterating every index in LiquidsLayer of the chunk (meaning we don't have to lookup solid blocks or do weird index calculation)
 - Replaced `Contains` with `StartsWith` improving performance and making it in line with the calculation during chunk generation (`BlockAccessorWorldGenPatch`)
 - Pulled `saltwater` check outside of the `water` check (I don't think saltwater should count as normal water after all...)
 - ModData is now checked on `null` instead of `0` since `0` is a completely valid end result of the scan.
 - Removed usage of `config.AquiferStep`, was used for sampling but I couldn't think of a good way to keep this while changing the logic to only iterate liquid layer (doesn't feel like it's really needed that much anymore with this change)
 ### **WARNING: this means that the aquifer rating will end up higher then before, might want to change configuration or just divide the end result with `config.AquiferStep` to keep it stable**

# BlockAccessorWorldGenPatch
- Removed `ChunkServerThread_GetGeneratingChunk_Patch` since this method did nothing more then initialize something that doesn't need to be initialized (also this method is called many times during generation of a single chunk, so wasn't a good point to hook)
- Simplified Logic
- Removed usage of `AssetLocation.ToString()` since this actually allocates a new string and there was no need for that.

# Other
- Added some TODO's and PERFORMANCE markers that should probably be looked at